### PR TITLE
fix: PaymentFacade.processRefund() 트랜잭션 원자성 복원

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/payment/PaymentFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/PaymentFacade.java
@@ -50,6 +50,7 @@ public class PaymentFacade {
         return payment;
     }
 
+    @Transactional
     public Payment processRefund(Long paymentId) {
         Payment refundPayment = paymentService.refund(paymentId);
 

--- a/src/test/java/kr/hhplus/be/server/application/payment/PaymentFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/payment/PaymentFacadeIntegrationTest.java
@@ -181,6 +181,41 @@ class PaymentFacadeIntegrationTest {
     }
 
     @Test
+    void 환불_중_재고복원_실패시_포인트와_결제상태도_함께_롤백된다() {
+        // given
+        User user = userRepository.save(User.create("테스터", 100000));
+        Product product1 = productRepository.save(new Product("상품1", 10000, 10, 1L));
+        Product product2 = productRepository.save(new Product("상품2", 5000, 10, 1L));
+
+        List<OrderLine> lines = List.of(
+                new OrderLine(product1.getId(), 1, product1.getPrice()),
+                new OrderLine(product2.getId(), 1, product2.getPrice())
+        );
+        Order order = orderService.create(user.getId(), lines);
+        Payment pay = paymentFacade.processPayment(order.getId(), order.getTotalAmount());
+
+        int pointAfterPayment = userRepository.findById(user.getId()).orElseThrow().getPoint();
+        int stockAfterPayment1 = productRepository.findById(product1.getId()).orElseThrow().getStock();
+
+        // 환불 처리 도중 두 번째 상품의 재고 복원이 실패하도록 미리 삭제해둔다
+        productRepository.deleteById(product2.getId());
+
+        // when & then
+        assertThrows(IllegalArgumentException.class,
+                () -> paymentFacade.processRefund(pay.getId())
+        );
+
+        // 트랜잭션 전체가 롤백되어야 하므로 첫 번째 상품 재고 복원, 포인트 복원,
+        // 결제 상태(REFUND) 변경까지 전부 반영되지 않은 상태여야 한다
+        assertThat(userRepository.findById(user.getId()).orElseThrow().getPoint())
+                .isEqualTo(pointAfterPayment);
+        assertThat(productRepository.findById(product1.getId()).orElseThrow().getStock())
+                .isEqualTo(stockAfterPayment1);
+        assertThat(paymentRepository.findById(pay.getId()).orElseThrow().getStatus())
+                .isEqualTo(PaymentStatus.COMPLETED);
+    }
+
+    @Test
     void 이미환불된_결제_환불시_IllegalStateException_발생() {
         // given
         User user = userRepository.save(User.create("테스터", 100000));


### PR DESCRIPTION
## 배경
`processPayment()`는 `@Transactional`인데 `processRefund()`는 없어서, 결제 상태 변경 → 포인트 복원 → 쿠폰 복원 → 재고 복원이 각자 독립된 트랜잭션으로 실행되고 있었다. 재고 복원 도중 예외가 발생하면 이미 반영된 앞 단계는 롤백되지 않아 부분 상태가 남을 수 있는 버그.

## 변경 사항
- `PaymentFacade.processRefund()`에 `@Transactional` 추가
- `PaymentFacadeIntegrationTest`에 검증 테스트 추가: 2개 상품 결제 후 환불 시, 두 번째 상품의 재고 복원이 실패하도록 만들고(사전 삭제) 첫 번째 상품 재고/포인트/결제 상태가 전부 롤백되는지 확인

## 검증
- `./gradlew clean build` 그린 확인 (238개 테스트 전부 통과)
- 새 테스트가 실제로 트랜잭션 롤백을 검증함 (수정 전이었다면 첫 상품 재고/포인트가 이미 반영된 채로 남아 테스트 실패했을 것)

## 관련 이슈
Closes #45