### PR TITLE
fix: 쿠폰 발급 컨슈머 예외 처리를 메시지 문자열 대신 타입 기반으로 변경

### DIFF
--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssuanceClosedException.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssuanceClosedException.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.coupon;
+
+public class CouponIssuanceClosedException extends IllegalStateException {
+    public CouponIssuanceClosedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponSoldOutException.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponSoldOutException.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.coupon;
+
+public class CouponSoldOutException extends IllegalStateException {
+    public CouponSoldOutException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/DuplicateCouponIssueException.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/DuplicateCouponIssueException.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.coupon;
+
+public class DuplicateCouponIssueException extends IllegalStateException {
+    public DuplicateCouponIssueException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponInventoryReader.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponInventoryReader.java
@@ -1,5 +1,8 @@
 package kr.hhplus.be.server.infrastructure.coupon;
 
+import kr.hhplus.be.server.domain.coupon.CouponIssuanceClosedException;
+import kr.hhplus.be.server.domain.coupon.CouponSoldOutException;
+import kr.hhplus.be.server.domain.coupon.DuplicateCouponIssueException;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SessionCallback;
@@ -43,11 +46,11 @@ public class CouponInventoryReader implements kr.hhplus.be.server.domain.coupon.
                 String issuedUsersKey = String.format(ISSUED_USERS_KEY, couponId);
 
                 if (!operations.hasKey(inventoryKey)) {
-                    throw new IllegalStateException("발급이 종료된 쿠폰입니다.");
+                    throw new CouponIssuanceClosedException("발급이 종료된 쿠폰입니다.");
                 }
 
                 if (Boolean.TRUE.equals(operations.opsForSet().isMember(issuedUsersKey, userId.toString()))) {
-                    throw new IllegalStateException("이미 발급받은 사용자입니다.");
+                    throw new DuplicateCouponIssueException("이미 발급받은 사용자입니다.");
                 }
                 operations.multi();
                 operations.opsForList().leftPop(inventoryKey);
@@ -55,7 +58,7 @@ public class CouponInventoryReader implements kr.hhplus.be.server.domain.coupon.
 
                 List<Object> results = operations.exec();
                 if (results.get(0) == null) {
-                    throw new IllegalStateException("재고가 소진되었습니다.");
+                    throw new CouponSoldOutException("재고가 소진되었습니다.");
                 }
 
                 return true;

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponIssuedConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponIssuedConsumer.java
@@ -1,6 +1,9 @@
 package kr.hhplus.be.server.infrastructure.coupon;
 
+import kr.hhplus.be.server.domain.coupon.CouponIssuanceClosedException;
 import kr.hhplus.be.server.domain.coupon.CouponService;
+import kr.hhplus.be.server.domain.coupon.CouponSoldOutException;
+import kr.hhplus.be.server.domain.coupon.DuplicateCouponIssueException;
 import kr.hhplus.be.server.domain.coupon.event.CouponIssuedMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
@@ -27,32 +30,18 @@ public class CouponIssuedConsumer {
                     message.getCouponId()
             );
             ack.acknowledge();
-        } catch (IllegalStateException e) {
-            String msg = e.getMessage();
-
-            if ("이미 발급받은 사용자입니다.".equals(msg)) {
-                log.warn("중복 발급 시도: couponId={}, userId={}",
-                        message.getCouponId(), message.getUserId());
-                ack.acknowledge();
-                return;
-            }
-
-            if ("재고가 소진되었습니다.".equals(msg)) {
-                log.warn("재고 소진 상태: couponId={}, userId={}",
-                        message.getCouponId(), message.getUserId());
-                ack.acknowledge();
-                return;
-            }
-
-            if ("발급이 종료된 쿠폰입니다.".equals(msg)) {
-                log.warn("발급 종료된 쿠폰 접근: couponId={}, userId={}",
-                        message.getCouponId(), message.getUserId());
-                ack.acknowledge();
-                return;
-            }
-
-        } catch (Exception e) {
-            throw e;
+        } catch (DuplicateCouponIssueException e) {
+            log.warn("중복 발급 시도: couponId={}, userId={}",
+                    message.getCouponId(), message.getUserId());
+            ack.acknowledge();
+        } catch (CouponSoldOutException e) {
+            log.warn("재고 소진 상태: couponId={}, userId={}",
+                    message.getCouponId(), message.getUserId());
+            ack.acknowledge();
+        } catch (CouponIssuanceClosedException e) {
+            log.warn("발급 종료된 쿠폰 접근: couponId={}, userId={}",
+                    message.getCouponId(), message.getUserId());
+            ack.acknowledge();
         }
     }
 }


### PR DESCRIPTION
## 배경
`CouponIssuedConsumer`가 `IllegalStateException`의 메시지 문자열을 정확히 매칭해서 ack/재시도 여부를 분기하고 있었다. 메시지 문구가 나중에 바뀌면(오타 수정, 문구 조정 등) 이 분기가 조용히 깨져서 정상 비즈니스 예외를 재시도 대상으로 잘못 처리하게 되는 문제.

## 변경 사항
- `DuplicateCouponIssueException`/`CouponSoldOutException`/`CouponIssuanceClosedException` 추가 (모두 `IllegalStateException` 서브타입 — 기존 `GlobalExceptionHandler` 매핑과 메시지 텍스트 기반 테스트 호환성 그대로 유지)
- `CouponInventoryReader`가 이 타입들을 던지도록 변경 (메시지 텍스트는 동일하게 유지)
- `CouponIssuedConsumer`가 메시지 문자열 매칭 대신 타입으로 catch하도록 변경

## 검증
`./gradlew clean build` 그린 확인 (238개 테스트 전부 통과, 기존 메시지 기반 assertion들도 서브타입 호환으로 그대로 통과)

## 관련 이슈
Closes #46