### PR TITLE
test: ProductFacadeIntegrationTest 캐시 취약성 제거

### DIFF
--- a/src/test/java/kr/hhplus/be/server/application/product/ProductFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/product/ProductFacadeIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -31,6 +32,9 @@ class ProductFacadeIntegrationTest {
     @Autowired
     OrderItemRepository orderItemRepository;
 
+    @Autowired
+    CacheManager cacheManager;
+
     @BeforeEach
     void cleanDb() {
         // OrderItem.order는 FK 제약이 없어(NO_CONSTRAINT) orderRepository.deleteAll()로
@@ -38,6 +42,14 @@ class ProductFacadeIntegrationTest {
         orderItemRepository.deleteAll();
         productRepository.deleteAll();
         orderRepository.deleteAll();
+
+        // productFacade.getPopularProducts()는 고정 키("top5")로 캐싱되는데, 로컬처럼
+        // Redis가 여러 번의 테스트 실행 사이에도 계속 떠있으면 이전 실행에서 캐싱된
+        // 값이 이번 실행의 새 데이터와 어긋나 테스트가 흔들릴 수 있다 - 매번 비워준다.
+        var cache = cacheManager.getCache("popularProducts");
+        if (cache != null) {
+            cache.clear();
+        }
     }
     @Test
     void 인기_상품_조회_성공() {


### PR DESCRIPTION
## 배경
`productFacade.getPopularProducts()`는 고정 키(`"top5"`)로 캐싱된다. 로컬처럼 docker-compose Redis가 여러 번의 `./gradlew test` 실행 사이에도 계속 떠있으면, TTL(~10분) 안에서는 이전 실행에서 캐싱된 상품 ID와 이번 실행의(매번 새로 뜨는 Testcontainer MySQL 기준) 상품 ID가 우연히 일치해야만 테스트가 통과하는 구조였다.

## 변경 사항
`@BeforeEach`에서 `CacheManager`로 `popularProducts` 캐시를 매번 명시적으로 비우도록 추가.

## 검증
- `./gradlew clean build` 그린 확인
- 같은 테스트를 연속 2회 재실행(`--rerun`)해도 안정적으로 통과하는 것을 확인 (수정 전이었다면 캐시 TTL 안에서 두 번째 실행이 흔들릴 수 있었음)

## 관련 이슈
Closes #49