### PR TITLE
fix: 주문 조회/취소 응답에서 items가 항상 빈 배열로 나오던 버그 수정

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
@@ -48,7 +48,7 @@ public class OrderFacade {
     public OrderResult.Create cancelOrder(Long orderId) {
         Order canceled = orderService.cancel(orderId);
 
-        List<OrderResult.Item> items = OrderMapper.toResultItems(canceled.getItems());
+        List<OrderResult.Item> items = OrderMapper.toResultItems(orderService.getOrderItems(canceled.getId()));
 
         int totalAmount = items.stream()
                 .mapToInt(i -> i.getQuantity() * i.getItemPrice())
@@ -67,7 +67,7 @@ public class OrderFacade {
         List<Order> orders = orderService.getOrdersByUser(userId);
         return orders.stream()
                 .map(order -> {
-                    List<OrderResult.Item> items = order.getItems().stream()
+                    List<OrderResult.Item> items = orderService.getOrderItems(order.getId()).stream()
                             .map(i -> new OrderResult.Item(i.getProductId(), i.getQuantity(), i.getOrderPrice()))
                             .collect(Collectors.toList());
                     return new OrderResult.Create(

--- a/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeIntegrationTest.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.application.order;
 
+import jakarta.persistence.EntityManager;
 import kr.hhplus.be.server.domain.order.OrderItemRepository;
 import kr.hhplus.be.server.domain.order.OrderRepository;
 import kr.hhplus.be.server.domain.product.Product;
@@ -37,6 +38,9 @@ class OrderFacadeIntegrationTest {
     @Autowired
     private OrderItemRepository orderItemRepository;
 
+    @Autowired
+    private EntityManager entityManager;
+
     @Test
     void 주문_생성_성공시_OrderResult가_반환된다() {
         // given
@@ -73,11 +77,20 @@ class OrderFacadeIntegrationTest {
         );
         OrderResult.Create created = orderFacade.processOrder(createCmd);
 
+        // 실제 운영에서는 주문 생성과 취소가 서로 다른 트랜잭션(별개의 HTTP 요청)에서
+        // 일어난다. 같은 트랜잭션 안에서는 Hibernate 영속성 컨텍스트가 이미 로드된
+        // Order 인스턴스를 그대로 재사용해서 @Transient인 items 필드가 우연히 채워진
+        // 것처럼 보일 수 있으므로, 영속성 컨텍스트를 비워 진짜 재조회 상황을 재현한다.
+        entityManager.clear();
+
         // when
         OrderResult.Create canceled = orderFacade.cancelOrder(created.getOrderId());
 
         // then
         assertThat(canceled.getStatus()).isEqualTo(OrderStatus.CANCEL);
+        assertThat(canceled.getItems()).hasSize(1);
+        assertThat(canceled.getItems().get(0).getProductId()).isEqualTo(p.getId());
+        assertThat(canceled.getItems().get(0).getQuantity()).isEqualTo(1);
         assertThat(canceled.getTotalPrice()).isEqualTo(p.getPrice());
     }
 
@@ -93,6 +106,10 @@ class OrderFacadeIntegrationTest {
         orderFacade.processOrder(cmd);
         orderFacade.processOrder(cmd);
 
+        // 실제 운영에서는 조회가 별도의 HTTP 요청(별도 트랜잭션)에서 일어난다.
+        // 영속성 컨텍스트를 비워서 진짜 재조회 상황을 재현한다 (아래 설명 참조).
+        entityManager.clear();
+
         // when
         List<OrderResult.Create> list = orderFacade.getOrdersByUser(user.getId());
 
@@ -100,6 +117,9 @@ class OrderFacadeIntegrationTest {
         assertThat(list).hasSize(2);
         list.forEach(r -> {
             assertThat(r.getUserId()).isEqualTo(user.getId());
+            assertThat(r.getItems()).hasSize(1);
+            assertThat(r.getItems().get(0).getProductId()).isEqualTo(p.getId());
+            assertThat(r.getItems().get(0).getQuantity()).isEqualTo(3);
             assertThat(r.getTotalPrice()).isEqualTo(3 * p.getPrice());
         });
     }

--- a/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeTest.java
@@ -88,13 +88,16 @@ class OrderFacadeTest {
     void 주문을_취소하면_상태가_CANCEL로_변경된다() {
         Long orderId = 1L;
         Long userId = 1L;
-        Order orderBefore = new Order(userId);
-        orderBefore.addLine(100L, 1, 10000);
-        Order canceled = new Order(userId);
-        canceled.addLine(100L, 1, 10000);
-        canceled.cancel();
+        Order canceled = Order.builder()
+                .id(orderId)
+                .userId(userId)
+                .totalAmount(10000)
+                .status(OrderStatus.CANCEL)
+                .build();
+        OrderItem item = new OrderItem(canceled, 100L, 1, 10000);
 
         when(orderService.cancel(orderId)).thenReturn(canceled);
+        when(orderService.getOrderItems(orderId)).thenReturn(List.of(item));
 
         OrderResult.Create result = orderFacade.cancelOrder(orderId);
 
@@ -107,11 +110,14 @@ class OrderFacadeTest {
     void 사용자별_주문목록을_정상적으로_반환한다() {
         // given
         Long userId = 1L;
-        Order o1 = new Order(userId);
-        o1.addLine(10L, 1, 10000);
-        Order o2 = new Order(userId);
-        o2.addLine(20L, 2, 15000);
+        Order o1 = Order.builder().id(1L).userId(userId).totalAmount(10000).status(OrderStatus.PENDING).build();
+        OrderItem o1Item = new OrderItem(o1, 10L, 1, 10000);
+        Order o2 = Order.builder().id(2L).userId(userId).totalAmount(30000).status(OrderStatus.PENDING).build();
+        OrderItem o2Item = new OrderItem(o2, 20L, 2, 15000);
+
         when(orderService.getOrdersByUser(userId)).thenReturn(List.of(o1, o2));
+        when(orderService.getOrderItems(1L)).thenReturn(List.of(o1Item));
+        when(orderService.getOrderItems(2L)).thenReturn(List.of(o2Item));
 
         List<OrderResult.Create> result = orderFacade.getOrdersByUser(userId);
 


### PR DESCRIPTION
## 배경
`Order.items`는 `@Transient` 필드라 JPA가 채워주지 않는데, `OrderFacade.getOrdersByUser()`/`cancelOrder()`가 DB에서 새로 조회한 `Order` 엔티티의 `getItems()`를 그대로 썼다. 실제 운영에서는 조회/취소가 생성과 별도의 HTTP 요청(별도 트랜잭션)에서 일어나므로, 실제 주문 개수와 무관하게 응답의 `items`가 항상 `[]`였다.

기존 통합 테스트가 이걸 못 잡은 이유: `@Transactional` 테스트 안에서 생성과 조회가 같은 영속성 컨텍스트를 공유해, Hibernate가 이미 로드된(items가 채워진) 같은 Order 인스턴스를 재사용했기 때문 — 실제 운영과 다르게 우연히 가려져 있었다.

## 변경 사항
- `OrderFacade.getOrdersByUser()`/`cancelOrder()`가 `orderService.getOrderItems(orderId)`로 별도 조회하도록 수정
- `OrderFacadeIntegrationTest`: `entityManager.clear()`로 영속성 컨텍스트를 비워 진짜 재조회 상황을 재현한 뒤 `items` 내용까지 검증하는 assertion 추가
- `OrderFacadeTest`(Mockito 단위 테스트): 새 시그니처에 맞게 `getOrderItems` 스텁 추가

## 검증
`./gradlew clean build` 그린 확인 (238개 테스트 전부 통과)

## 관련 이슈
Closes #55