### PR TITLE
fix: 주문 생성 시 클라이언트가 보낸 가격을 신뢰하던 취약점 수정

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
@@ -26,8 +26,14 @@ public class OrderFacade {
             productService.checkStock(item.getProductId(), item.getQuantity());
         }
 
+        // 주문 가격은 클라이언트가 보낸 itemPrice를 신뢰하지 않고, 서버가 실제
+        // Product.price를 조회해 강제한다 (클라이언트가 임의 가격으로 주문하는 것 방지).
         List<OrderLine> lines = command.getItems().stream()
-                .map(i -> new OrderLine(i.getProductId(), i.getQuantity(), i.getItemPrice()))
+                .map(i -> new OrderLine(
+                        i.getProductId(),
+                        i.getQuantity(),
+                        productService.getProduct(i.getProductId()).getPrice()
+                ))
                 .collect(Collectors.toList());
 
         Order saved = orderService.create(command.getUserId(), lines);

--- a/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeIntegrationTest.java
@@ -67,6 +67,27 @@ class OrderFacadeIntegrationTest {
     }
 
     @Test
+    void 주문_생성시_클라이언트가_보낸_가격은_무시되고_실제_상품가격이_적용된다() {
+        // given
+        User user = userRepository.save(User.create("테스터", 0));
+        Product product = productRepository.save(new Product("상품", 15000, 100, user.getId()));
+
+        // 클라이언트가 실제 가격(15000)과 다른 조작된 가격(1원)을 보냄
+        OrderCommand.Create cmd = new OrderCommand.Create(
+                user.getId(),
+                List.of(new OrderCommand.Item(product.getId(), 2, 1))
+        );
+
+        // when
+        OrderResult.Create result = orderFacade.processOrder(cmd);
+
+        // then: 조작된 가격(1원 * 2 = 2)이 아니라 실제 상품 가격(15000 * 2)이 적용돼야 한다
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getItems().get(0).getItemPrice()).isEqualTo(15000);
+        assertThat(result.getTotalPrice()).isEqualTo(2 * 15000);
+    }
+
+    @Test
     void 주문_취소_성공시_Status가_CANCEL로_변경된다() {
         // given
         User user = userRepository.save(User.create("테스터", 0));

--- a/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeTest.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.application.order;
 
 import kr.hhplus.be.server.domain.order.*;
+import kr.hhplus.be.server.domain.product.Product;
 import kr.hhplus.be.server.domain.product.ProductService;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.domain.user.UserPointService;
@@ -43,7 +44,8 @@ class OrderFacadeTest {
 
         doNothing().when(productService).checkStock(101L, 2);
         doNothing().when(productService).checkStock(102L, 1);
-
+        when(productService.getProduct(101L)).thenReturn(new Product("상품1", 15000, 100, 1L));
+        when(productService.getProduct(102L)).thenReturn(new Product("상품2", 20000, 100, 1L));
 
         Order dummyOrder = new Order(userId);
         dummyOrder.addLine(101L, 2, 15000);


### PR DESCRIPTION
## 배경
`OrderRequest.Item.itemPrice`(클라이언트 입력)가 검증 없이 그대로 `OrderLine.orderPrice`로 들어가고 있었다. 실제 `Product.price`와 대조하는 코드가 없어서 클라이언트가 임의 가격(예: 1원)으로 아무 상품이나 주문할 수 있었다.

## 변경 사항
- `OrderFacade.processOrder()`가 클라이언트의 `itemPrice`를 무시하고 항상 `productService.getProduct(productId)`로 조회한 실제 가격을 쓰도록 수정
- `OrderFacadeTest`(Mockito): `getProduct` 스텁 추가
- `OrderFacadeIntegrationTest`: 조작된 가격이 무시되고 실제 상품 가격이 적용되는지 검증하는 테스트 추가

## 검증
`./gradlew clean build` 그린 확인 (238개 테스트 전부 통과)

## 관련 이슈
Closes #56