### PR TITLE
fix: Payment.amount 검증 부재 — 서버 계산 금액으로 강제

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/payment/PaymentFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/PaymentFacade.java
@@ -34,9 +34,18 @@ public class PaymentFacade {
     @Transactional
     public Payment processPayment(Long orderId, int paymentAmount) {
         Order order = orderService.getOrderOrThrowPaid(orderId);
+
+        // paymentAmount는 클라이언트가 주문 금액에 동의했다는 확인 값일 뿐, 실제 결제/환불
+        // 금액 계산의 근거로 쓰지 않는다. 서버가 계산한 주문 총액과 다르면 조작된 값으로 보고 거부한다.
+        if (paymentAmount != order.getTotalAmount()) {
+            throw new IllegalArgumentException(
+                    "결제 금액이 주문 금액과 일치하지 않습니다. paymentAmount=" + paymentAmount
+                            + ", orderTotalAmount=" + order.getTotalAmount());
+        }
+
         Long couponId = couponService.getAvailableCouponId(order.getUserId());
 
-        Payment payment = calculateDiscountAndCreatePayment(order.getUserId(), orderId, couponId, order.getTotalAmount(), paymentAmount);
+        Payment payment = calculateDiscountAndCreatePayment(order.getUserId(), orderId, couponId, order.getTotalAmount());
 
         order = orderService.pay(orderId);
 
@@ -70,7 +79,7 @@ public class PaymentFacade {
         return refundPayment;
     }
 
-    private Payment calculateDiscountAndCreatePayment(Long userId, Long orderId, Long couponId, int totalAmount, int paymentAmount) {
+    private Payment calculateDiscountAndCreatePayment(Long userId, Long orderId, Long couponId, int totalAmount) {
         int discountAmount = 0;
         if (couponId != null) {
             couponEventPublisher.publishCouponValidate(new CouponValidateEvent(userId, orderId, couponId));
@@ -80,6 +89,6 @@ public class PaymentFacade {
             pointEventPublisher.publishPointUsed(new PointUseEvent(userId, totalAmount));
         }
 
-        return paymentService.create(orderId, paymentAmount - discountAmount, couponId);
+        return paymentService.create(orderId, totalAmount - discountAmount, couponId);
     }
 }

--- a/src/test/java/kr/hhplus/be/server/application/payment/PaymentFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/payment/PaymentFacadeIntegrationTest.java
@@ -130,6 +130,27 @@ class PaymentFacadeIntegrationTest {
     }
 
     @Test
+    void 클라이언트가_보낸_결제금액이_주문금액과_다르면_IllegalArgumentException_발생() {
+        // given
+        User user = userRepository.save(User.create("테스터", 100000));
+        Product product = productRepository.save(new Product("상품1", 30000, 10, 1L));
+
+        List<OrderLine> lines = List.of(new OrderLine(product.getId(), 1, product.getPrice()));
+        Order order = orderService.create(user.getId(), lines);
+
+        // when & then: 실제 주문 금액(30000)과 다른 조작된 금액(1원)을 보냄
+        assertThrows(IllegalArgumentException.class,
+                () -> paymentFacade.processPayment(order.getId(), 1)
+        );
+
+        // 결제/포인트/재고 전부 반영되지 않아야 한다
+        assertThat(userRepository.findById(user.getId()).orElseThrow().getPoint())
+                .isEqualTo(100000);
+        assertThat(productRepository.findById(product.getId()).orElseThrow().getStock())
+                .isEqualTo(10);
+    }
+
+    @Test
     void 재고부족_결제시_IllegalStateException_발생() {
         // given
         User user = userRepository.save(User.create("테스터", 100000));


### PR DESCRIPTION
## 배경
`PaymentRequest.paymentAmount`(클라이언트 입력)가 검증 없이 그대로 `Payment.amount` 계산에 쓰이고 있었다. 포인트 차감은 서버 계산값(`order.getTotalAmount()`) 기준이라 결제 시점엔 안전했지만, 저장되는 `Payment.amount`는 클라이언트가 조작 가능했고 이 값이 `processRefund()`에서 그대로 환불 금액으로 쓰였다.

## 변경 사항
- `processPayment()`에서 `paymentAmount`를 `order.getTotalAmount()`와 대조, 불일치 시 `IllegalArgumentException`
- `Payment.amount` 계산도 클라이언트 값이 아니라 서버 계산 `totalAmount` 기준으로 강제(방어적 이중 안전장치)
- 통합 테스트에 조작된 결제금액으로 요청 시 예외 발생 + 포인트/재고 무변경 검증 추가

## 검증
`./gradlew clean build` 그린 확인 (238개 테스트 전부 통과)

## 관련 이슈
Closes #57