### PR TITLE
fix: Kafka 재전달 시 인기상품 통계 중복 카운트 방지

### DIFF
--- a/src/main/java/kr/hhplus/be/server/infrastructure/payment/PaymentCompletedConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/payment/PaymentCompletedConsumer.java
@@ -6,11 +6,13 @@ import kr.hhplus.be.server.domain.order.OrderService;
 import kr.hhplus.be.server.domain.payment.event.PaymentCompletedEvent;
 import kr.hhplus.be.server.domain.payment.event.PaymentEventPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
@@ -18,15 +20,28 @@ public class PaymentCompletedConsumer {
     private final PopularProductService popularProductService;
     private final OrderService orderService;
     private final PaymentEventPort paymentEventPort;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String PROCESSED_KEY_PREFIX = "payment:completed:processed:";
+    private static final long PROCESSED_KEY_TTL_HOURS = 24;
 
     @KafkaListener(topics = "${topic.payment-completed}", groupId = "payment-service")
     public void handlePaymentCompleted(PaymentCompletedEvent event, Acknowledgment acknowledgment) {
         try {
-            List<OrderItem> items = orderService.getOrderItems(event.getOrder().getId());
-            for (OrderItem item : items) {
-                popularProductService.incrementProductSales(item.getProductId(), item.getQuantity());
+            // Kafka at-least-once 재전달로 같은 이벤트가 중복 소비될 수 있으므로,
+            // paymentId 기준 멱등 키(SETNX)로 이미 처리한 메시지는 통계 반영 없이 스킵한다.
+            String processedKey = PROCESSED_KEY_PREFIX + event.getPayment().getId();
+            Boolean firstProcessing = redisTemplate.opsForValue()
+                    .setIfAbsent(processedKey, "1", PROCESSED_KEY_TTL_HOURS, TimeUnit.HOURS);
+
+            if (Boolean.TRUE.equals(firstProcessing)) {
+                List<OrderItem> items = orderService.getOrderItems(event.getOrder().getId());
+                for (OrderItem item : items) {
+                    popularProductService.incrementProductSales(item.getProductId(), item.getQuantity());
+                }
+                paymentEventPort.send(event);
             }
-            paymentEventPort.send(event);
+
             acknowledgment.acknowledge();
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/test/java/kr/hhplus/be/server/infrastructure/payment/PaymentCompletedConsumerTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/payment/PaymentCompletedConsumerTest.java
@@ -1,0 +1,90 @@
+package kr.hhplus.be.server.infrastructure.payment;
+
+import kr.hhplus.be.server.domain.order.Order;
+import kr.hhplus.be.server.domain.order.OrderItem;
+import kr.hhplus.be.server.domain.order.OrderLine;
+import kr.hhplus.be.server.domain.order.OrderService;
+import kr.hhplus.be.server.domain.payment.Payment;
+import kr.hhplus.be.server.domain.payment.PaymentRepository;
+import kr.hhplus.be.server.domain.payment.event.PaymentCompletedEvent;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.domain.product.ProductRepository;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class PaymentCompletedConsumerTest {
+
+    @Autowired
+    private PaymentCompletedConsumer paymentCompletedConsumer;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final String PRODUCT_SALES_KEY = "product:sales:daily";
+    private static final String PROCESSED_KEY_PREFIX = "payment:completed:processed:";
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate.delete(redisTemplate.keys(PRODUCT_SALES_KEY + "*"));
+        redisTemplate.delete(redisTemplate.keys(PROCESSED_KEY_PREFIX + "*"));
+    }
+
+    @Test
+    void 같은_결제완료_이벤트가_재전달돼도_인기상품_통계는_한번만_반영된다() {
+        // given: 실제 Kafka 컨슈머가 자동으로 소비하기 전에, 같은 이벤트를 직접 두 번 전달해
+        // 재전달(at-least-once) 상황을 재현한다.
+        User user = userRepository.save(User.create("테스터", 100000));
+        Product product = productRepository.save(new Product("상품1", 10000, 100, user.getId()));
+
+        List<OrderLine> lines = List.of(new OrderLine(product.getId(), 2, product.getPrice()));
+        Order order = orderService.create(user.getId(), lines);
+        Payment payment = paymentRepository.save(Payment.withoutCoupon(order.getId(), order.getTotalAmount()));
+        payment.complete();
+        paymentRepository.save(payment);
+
+        List<OrderItem> items = orderService.getOrderItems(order.getId());
+        PaymentCompletedEvent event = new PaymentCompletedEvent(payment, order, items);
+
+        Acknowledgment ack1 = mock(Acknowledgment.class);
+        Acknowledgment ack2 = mock(Acknowledgment.class);
+
+        // when: 동일 이벤트를 두 번 처리 (Kafka 재전달 재현)
+        paymentCompletedConsumer.handlePaymentCompleted(event, ack1);
+        paymentCompletedConsumer.handlePaymentCompleted(event, ack2);
+
+        // then: 통계는 한 번만 반영되고, 재전달 건도 정상적으로 ack는 된다
+        String today = LocalDate.now().format(DateTimeFormatter.ISO_DATE);
+        Double score = redisTemplate.opsForZSet().score(PRODUCT_SALES_KEY + ":" + today, product.getId().toString());
+        assertThat(score).isEqualTo(2.0);
+
+        verify(ack1).acknowledge();
+        verify(ack2).acknowledge();
+    }
+}


### PR DESCRIPTION
## 문제
`PaymentCompletedConsumer`는 Kafka at-least-once 전달 방식을 사용하는 컨슈머라 동일한 결제완료 이벤트가 재전달될 수 있다. 재전달이 일어나면 `popularProductService.incrementProductSales(...)`가 같은 주문 항목에 대해 여러 번 호출되어 인기상품 통계(Redis ZSET 점수)가 실제 판매량보다 부풀려진다.

## 수정
- `PaymentCompletedConsumer.handlePaymentCompleted`에서 `event.getPayment().getId()` 기준 멱등 키(`payment:completed:processed:{paymentId}`)를 Redis `SETNX`(24시간 TTL)로 선점
- 최초 처리(키 선점 성공)일 때만 통계 반영 + `paymentEventPort.send(event)` 호출
- 이미 처리된 재전달 건은 통계/전송 없이 스킵하되, `acknowledgment.acknowledge()`는 정상 호출해 무한 재전달 방지

## 테스트
- `PaymentCompletedConsumerTest.같은_결제완료_이벤트가_재전달돼도_인기상품_통계는_한번만_반영된다` 추가: 동일 이벤트를 직접 두 번 전달해 재전달 상황을 재현하고, Redis 점수가 한 번만 반영됨을 검증
- `./gradlew clean build` 전체 그린 확인 (BUILD SUCCESSFUL in 38s)

## 관련 이슈
Closes #58