### PR TITLE
feat: 주요 API에 Bean Validation(@Valid) 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/java/kr/hhplus/be/server/interfaces/UserPoint/UserPointController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/UserPoint/UserPointController.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.interfaces.UserPoint;
 
+import jakarta.validation.Valid;
 import kr.hhplus.be.server.application.user.UserPointFacade;
 import kr.hhplus.be.server.domain.user.User;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,7 @@ public class UserPointController {
     private final UserPointFacade userPointFacade;
 
     @PostMapping("/charge")
-    public ResponseEntity<User> chargePoint(@RequestBody UserPointRequest request) {
+    public ResponseEntity<User> chargePoint(@Valid @RequestBody UserPointRequest request) {
         User updatedUser = userPointFacade.chargePoint(request.getUserId(), request.getChargeAmount());
         return ResponseEntity.ok(updatedUser);
     }

--- a/src/main/java/kr/hhplus/be/server/interfaces/UserPoint/UserPointRequest.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/UserPoint/UserPointRequest.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.interfaces.UserPoint;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,10 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserPointRequest {
+    @NotNull
     private Long userId;
+
+    // chargeAmount 범위(0보다 커야 함, 1회/총 한도)는 기존 도메인 로직(UserPointFacade)이
+    // 구체적인 한국어 메시지로 이미 검증하고 있어 여기서 중복 제약을 걸지 않는다.
     private int chargeAmount;
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/advice/GlobalExceptionHandler.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/advice/GlobalExceptionHandler.java
@@ -2,8 +2,11 @@ package kr.hhplus.be.server.interfaces.advice;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -11,6 +14,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException ex) {
         return ResponseEntity.badRequest().body(ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(e -> e.getField() + ": " + e.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse("VALIDATION_FAIL", message));
     }
 
     @ExceptionHandler(IllegalStateException.class)

--- a/src/main/java/kr/hhplus/be/server/interfaces/order/OrderController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/order/OrderController.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.interfaces.order;
 
+import jakarta.validation.Valid;
 import kr.hhplus.be.server.application.order.OrderCommand;
 import kr.hhplus.be.server.application.order.OrderFacade;
 import kr.hhplus.be.server.application.order.OrderResult;
@@ -18,7 +19,7 @@ public class OrderController {
     private final OrderFacade orderFacade;
 
     @PostMapping
-    public ResponseEntity<OrderResponse> create(@RequestBody OrderRequest request) {
+    public ResponseEntity<OrderResponse> create(@Valid @RequestBody OrderRequest request) {
         List<OrderCommand.Item> items = request.getItems().stream()
                 .map(i -> new OrderCommand.Item(i.getProductId(), i.getQuantity(),i.getItemPrice()))
                 .collect(Collectors.toList());

--- a/src/main/java/kr/hhplus/be/server/interfaces/order/OrderRequest.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/order/OrderRequest.java
@@ -1,5 +1,10 @@
 package kr.hhplus.be.server.interfaces.order;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,16 +15,23 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OrderRequest {
+    @NotNull
     private Long userId;
 
-    private List<Item> items;
+    @NotEmpty(message = "주문 항목이 비어 있습니다.")
+    private List<@Valid Item> items;
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Item {
+        @NotNull
         private Long productId;
+
+        @Positive
         private int quantity;
+
+        @PositiveOrZero
         private int itemPrice;
     }
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/payment/PaymentController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/payment/PaymentController.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.interfaces.payment;
 
+import jakarta.validation.Valid;
 import kr.hhplus.be.server.application.payment.PaymentFacade;
 import kr.hhplus.be.server.domain.payment.Payment;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,7 @@ public class PaymentController {
     @PatchMapping("/{orderId}/pay")
     public ResponseEntity<Payment> completePayment(
             @PathVariable Long orderId,
-            @RequestBody PaymentRequest request
+            @Valid @RequestBody PaymentRequest request
     ) {
         Payment payment = paymentFacade.processPayment(orderId, request.getPaymentAmount());
         return ResponseEntity.ok(payment);

--- a/src/main/java/kr/hhplus/be/server/interfaces/payment/PaymentRequest.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/payment/PaymentRequest.java
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.interfaces.payment;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +11,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PaymentRequest {
-    @NotNull
+    // int(원시타입)는 null이 될 수 없어 @NotNull은 항상 통과하는 무의미한 검증이었다.
+    // 실제로 막아야 할 건 0 이하의 조작된 결제 금액이므로 @Positive로 교체.
+    @Positive
     private int paymentAmount;
 }

--- a/src/test/java/kr/hhplus/be/server/interfaces/payment/PaymentControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/payment/PaymentControllerTest.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -162,20 +163,18 @@ class PaymentControllerTest {
     }
 
     @Test
-    void 결제_실패_예외() throws Exception {
+    void 결제_실패_paymentAmount_0이하는_검증에서_거부된다() throws Exception {
         // given
         Long orderId = 1L;
-        int invalidAmount = 0;
 
-        doThrow(new IllegalArgumentException("포인트는 0보다 커야 합니다."))
-                .when(paymentFacade).processPayment(orderId, invalidAmount);
-
-        // when & then
+        // when & then: paymentAmount<=0은 @Valid 검증에서 걸러져 facade까지 도달하지 않는다
         mockMvc.perform(patch("/payments/{orderId}/pay", orderId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"paymentAmount\": 0}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(content().string(containsString("포인트는 0보다 커야 합니다.")));
+                .andExpect(content().string(containsString("paymentAmount")));
+
+        verifyNoInteractions(paymentFacade);
     }
 
     @Test


### PR DESCRIPTION
## 문제
프로젝트 전체에 Bean Validation(`@Valid`)이 사실상 전무했다. `PaymentRequest`에 `@NotNull`이 붙어 있었지만 (1) `spring-boot-starter-validation` 의존성 자체가 없어 검증기가 아예 동작하지 않았고 (2) 애초에 `int` 원시타입에 `@NotNull`은 항상 통과하는 무의미한 제약이었다. 컨트롤러 어디에도 `@Valid`가 걸려 있지 않아 구조적으로 잘못된 요청(빈 리스트, null id, 음수 값 등)이 그대로 서비스 계층까지 흘러들어갔다.

## 수정
- `spring-boot-starter-validation` 의존성 추가
- `OrderController.create` / `UserPointController.chargePoint` / `PaymentController.completePayment`에 `@Valid` 적용
- `OrderRequest`: `userId`/`Item.productId` not-null, `items` not-empty, `quantity` 양수, `itemPrice` 0 이상
- `PaymentRequest`: 무의미했던 `@NotNull` → `@Positive`로 교체
- `UserPointRequest`: `userId` not-null만 추가 — `chargeAmount`의 범위(1회/총 한도)는 기존 도메인 로직(`UserPointFacade`)이 이미 구체적인 한국어 메시지로 검증하고 있어 중복 제약을 걸지 않음 (메시지 중복/불일치 방지)
- `GlobalExceptionHandler`에 `MethodArgumentNotValidException` 핸들러 추가 → 400 + 필드별 오류 메시지 반환

## 테스트 변경
- `PaymentControllerTest.결제_실패_예외`: `paymentAmount=0`을 facade가 던지는 걸로 목킹해 검증하던 기존 테스트는 이제 `@Valid`가 facade 호출 전에 걸러내므로, 검증 단계에서 400이 나오고 facade가 호출되지 않음을 확인하는 방식으로 갱신
- `./gradlew clean build` 전체 그린 확인 (BUILD SUCCESSFUL in 38s)

## 관련 이슈
Closes #59