### PR TITLE
refactor: PaymentController/CouponController 응답을 엔티티 대신 DTO로 통일

### DIFF
--- a/src/main/java/kr/hhplus/be/server/interfaces/coupon/CouponController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/coupon/CouponController.java
@@ -1,7 +1,6 @@
 package kr.hhplus.be.server.interfaces.coupon;
 
 import kr.hhplus.be.server.application.coupon.CouponFacade;
-import kr.hhplus.be.server.domain.coupon.Coupon;
 import kr.hhplus.be.server.domain.coupon.UserCoupon;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,9 +17,10 @@ public class CouponController {
 
     @PostMapping("/{userId}/issue")
     @ResponseStatus(HttpStatus.CREATED)
-    public UserCoupon issueCoupon(@PathVariable Long userId,
+    public UserCouponResponse issueCoupon(@PathVariable Long userId,
                                   @RequestParam Long couponId) {
-        return couponFacade.issue(userId, couponId);
+        UserCoupon userCoupon = couponFacade.issue(userId, couponId);
+        return UserCouponResponse.from(userCoupon);
     }
 
     @PostMapping("/{userId}/issue-async")
@@ -42,7 +42,7 @@ public class CouponController {
     }
 
     @GetMapping
-    public Coupon getCoupon(@RequestParam Long couponId) {
-        return couponFacade.getCouponOrThrow(couponId);
+    public CouponResponse getCoupon(@RequestParam Long couponId) {
+        return CouponResponse.from(couponFacade.getCouponOrThrow(couponId));
     }
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/coupon/CouponResponse.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/coupon/CouponResponse.java
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.interfaces.coupon;
+
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CouponResponse {
+    private Long id;
+    private String name;
+    private int discountRate;
+    private int maxDiscountAmount;
+    private String status;
+    private LocalDateTime expirationAt;
+    private LocalDateTime createdAt;
+    private int limitCount;
+    private int issuedCount;
+    private boolean expired;
+
+    public static CouponResponse from(Coupon coupon) {
+        return new CouponResponse(
+                coupon.getId(),
+                coupon.getName(),
+                coupon.getDiscountRate(),
+                coupon.getMaxDiscountAmount(),
+                coupon.getStatus().name(),
+                coupon.getExpirationAt(),
+                coupon.getCreatedAt(),
+                coupon.getLimitCount(),
+                coupon.getIssuedCount(),
+                coupon.isExpired()
+        );
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/coupon/UserCouponResponse.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/coupon/UserCouponResponse.java
@@ -1,0 +1,31 @@
+package kr.hhplus.be.server.interfaces.coupon;
+
+import kr.hhplus.be.server.domain.coupon.UserCoupon;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCouponResponse {
+    private Long id;
+    private Long userId;
+    private Long couponId;
+    private String status;
+    private LocalDateTime issuedAt;
+    private LocalDateTime usedAt;
+
+    public static UserCouponResponse from(UserCoupon userCoupon) {
+        return new UserCouponResponse(
+                userCoupon.getId(),
+                userCoupon.getUserId(),
+                userCoupon.getCouponId(),
+                userCoupon.getStatus().name(),
+                userCoupon.getIssuedAt(),
+                userCoupon.getUsedAt()
+        );
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/payment/PaymentController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/payment/PaymentController.java
@@ -15,12 +15,12 @@ public class PaymentController {
     private final PaymentFacade paymentFacade;
 
     @PatchMapping("/{orderId}/pay")
-    public ResponseEntity<Payment> completePayment(
+    public ResponseEntity<PaymentResponse> completePayment(
             @PathVariable Long orderId,
             @Valid @RequestBody PaymentRequest request
     ) {
         Payment payment = paymentFacade.processPayment(orderId, request.getPaymentAmount());
-        return ResponseEntity.ok(payment);
+        return ResponseEntity.ok(PaymentResponse.from(payment));
     }
 
     @PatchMapping("/{paymentId}/refund")


### PR DESCRIPTION
## 문제
`CouponController.issueCoupon`/`getCoupon`과 `PaymentController.completePayment`가 JPA 엔티티(`UserCoupon`, `Coupon`, `Payment`)를 그대로 응답으로 반환하고 있었다. lazy 필드가 없어 즉시 문제가 되는 버그는 아니지만(#61에서 확인), 인터페이스 계층이 도메인 엔티티 구조에 직접 결합되어 엔티티 필드 변경이 API 응답에 그대로 새는 구조였다.

## 수정
- `CouponResponse`/`UserCouponResponse` 추가, `CouponController`가 이 DTO를 반환하도록 변경
- `PaymentController.completePayment`도 이미 refund에서 쓰던 `PaymentResponse`로 통일 (pay/refund 응답 방식 일관성 확보)

## 참고
- `CouponResponse`는 `Coupon.isExpired()` 파생 필드(`expired`)도 그대로 유지 — 기존 `CouponControllerTest`가 엔티티 직렬화 결과와 JSON 비교를 하고 있어 필드 누락 시 실패함을 빌드로 확인, 포함시켜 해결
- `./gradlew clean build` 전체 그린 확인 (BUILD SUCCESSFUL in 40s)

## 관련 이슈
Closes #61