### PR TITLE
test: 포인트 동시성 테스트 assertion을 정확한 기대값으로 강화

### DIFF
--- a/src/test/java/kr/hhplus/be/server/application/user/UserPointConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/user/UserPointConcurrencyTest.java
@@ -55,10 +55,12 @@ class UserPointConcurrencyTest {
         // when
         User updated = userRepository.findById(user.getId()).orElseThrow();
         List<PointHistory> histories = pointHistoryRepository.findByUserId(user.getId());
-        // then
-        assertThat(updated.getPoint()).isBetween(0, initialPoint);
-        assertThat(histories.size()).isLessThanOrEqualTo(initialPoint/amount);
-
+        // then: 락이 제대로 걸리면 1000/200=5건만 성공해 정확히 0원이 남고, 5건의 사용 이력만
+        // 남는다. 범위(isBetween/isLessThanOrEqualTo)로만 검증하면 락이 일부만 걸리는 경우도
+        // 우연히 통과할 수 있어 정확한 기대값으로 검증한다.
+        int expectedSuccessCount = initialPoint / amount;
+        assertThat(updated.getPoint()).isEqualTo(initialPoint - expectedSuccessCount * amount);
+        assertThat(histories).hasSize(expectedSuccessCount);
     }
 
     @Test


### PR DESCRIPTION
## 문제
`UserPointConcurrencyTest.동시_포인트_사용_정상_처리_확인`이 `isBetween(0, initialPoint)`, `isLessThanOrEqualTo(initialPoint/amount)` 같은 느슨한 범위 검증만 하고 있었다. 락이 부분적으로만 걸려 일부 스레드가 잘못 통과해도 이 범위 안에 들면 테스트가 그냥 통과해버리는 구조라, 실제로는 동시성 버그를 못 잡아내는 테스트였다.

## 수정
- 초기 1000원 / 1회 200원 / 10스레드 조건에서 정확히 5건만 성공해야 하므로, 잔액은 정확히 0원, 사용 이력은 정확히 5건으로 검증하도록 강화
- 실행 결과 정확한 기대값으로도 그대로 통과 → 현재 락 구현이 실제로 올바르게 동작 중임을 재확인
- `./gradlew clean build` 전체 그린 확인 (BUILD SUCCESSFUL in 39s)

## 관련 이슈
Closes #62